### PR TITLE
bump version to 0.2.778, clean up installation steps

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,13 +1,13 @@
 pkgbase = templ-bin
 	pkgdesc = A language for writing HTML user interfaces in Go.
-	pkgver = 0.2.771
-	pkgrel = 2
+	pkgver = 0.2.778
+	pkgrel = 1
 	url = https://github.com/a-h/templ
 	arch = x86_64
 	license = MIT
 	provides = templ
 	conflicts = templ
-	source_x86_64 = templ-x86-x64-0.2.771.tar.gz::https://github.com/a-h/templ/releases/download/v0.2.771/templ_Linux_x86_64.tar.gz
-	sha256sums_x86_64 = 216aff42df8a7eb8855a0ee8f9b500069fb8e509157fc2aa5fad0f48e9a6d53e
+	source_x86_64 = templ-x86-x64-0.2.778.tar.gz::https://github.com/a-h/templ/releases/download/v0.2.778/templ_Linux_x86_64.tar.gz
+	sha256sums_x86_64 = 2cb042475d8bb215b4a7b586d069f74f05ae2709266208aaf83e6d8d3fc73eff
 
 pkgname = templ-bin

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = templ-bin
 	pkgdesc = A language for writing HTML user interfaces in Go.
 	pkgver = 0.2.648
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/a-h/templ
 	arch = x86_64
 	license = MIT

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = templ-bin
 	pkgdesc = A language for writing HTML user interfaces in Go.
 	pkgver = 0.2.771
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/a-h/templ
 	arch = x86_64
 	license = MIT

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,13 +1,13 @@
 pkgbase = templ-bin
 	pkgdesc = A language for writing HTML user interfaces in Go.
-	pkgver = 0.2.648
-	pkgrel = 2
+	pkgver = 0.2.771
+	pkgrel = 1
 	url = https://github.com/a-h/templ
 	arch = x86_64
 	license = MIT
 	provides = templ
 	conflicts = templ
-	source_x86_64 = templ-x86-x64-0.2.648.tar.gz::https://github.com/a-h/templ/releases/download/v0.2.648/templ_Linux_x86_64.tar.gz
-	sha256sums_x86_64 = 3abad775c8ef0ff42181158e58b6d8746be7d3e2e194974345d97556ad668259
+	source_x86_64 = templ-x86-x64-0.2.771.tar.gz::https://github.com/a-h/templ/releases/download/v0.2.771/templ_Linux_x86_64.tar.gz
+	sha256sums_x86_64 = 216aff42df8a7eb8855a0ee8f9b500069fb8e509157fc2aa5fad0f48e9a6d53e
 
 pkgname = templ-bin

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,15 +2,15 @@
 # Contributor: thdxr (original PKGBUILD)
 # Contributor: Noel Jacob (bun-bin PKGBUILD)
 pkgname=templ-bin
-pkgver=0.2.771
-pkgrel=2
+pkgver=0.2.778
+pkgrel=1
 pkgdesc="A language for writing HTML user interfaces in Go."
 arch=('x86_64')
 url="https://github.com/a-h/templ"
 license=('MIT')
 provides=('templ')
 conflicts=('templ')
-sha256sums_x86_64=('216aff42df8a7eb8855a0ee8f9b500069fb8e509157fc2aa5fad0f48e9a6d53e')
+sha256sums_x86_64=('2cb042475d8bb215b4a7b586d069f74f05ae2709266208aaf83e6d8d3fc73eff')
 source_x86_64=("templ-x86-x64-${pkgver}.tar.gz::https://github.com/a-h/templ/releases/download/v${pkgver}/templ_Linux_x86_64.tar.gz")
 
 package() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 # Contributor: Noel Jacob (bun-bin PKGBUILD)
 pkgname=templ-bin
 pkgver=0.2.648
-pkgrel=1
+pkgrel=2
 pkgdesc="A language for writing HTML user interfaces in Go."
 arch=('x86_64')
 url="https://github.com/a-h/templ"
@@ -12,17 +12,8 @@ provides=('templ')
 conflicts=('templ')
 sha256sums_x86_64=("3abad775c8ef0ff42181158e58b6d8746be7d3e2e194974345d97556ad668259")
 source_x86_64=("templ-x86-x64-${pkgver}.tar.gz::https://github.com/a-h/templ/releases/download/v${pkgver}/templ_Linux_x86_64.tar.gz")
-build() {
-  install -dm755 "completions"
-  SHELL=zsh "./templ" completions > "completions/templ.zsh"
-  SHELL=bash "./templ" completions > "completions/templ.bash"
-  SHELL=fish "./templ" completions > "completions/templ.fish"
-}
+
 package() {
   install -Dm755 "./templ" "${pkgdir}/usr/bin/templ"
-  
-  install -Dm644 completions/templ.zsh "${pkgdir}/usr/share/zsh/site-functions/_templ"
-  install -Dm644 completions/templ.bash "${pkgdir}/usr/share/bash-completion/completions/templ"
-  install -Dm644 completions/templ.fish "${pkgdir}/usr/share/fish/vendor_completions.d/templ.fish"
 }
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 # Contributor: Noel Jacob (bun-bin PKGBUILD)
 pkgname=templ-bin
 pkgver=0.2.771
-pkgrel=1
+pkgrel=2
 pkgdesc="A language for writing HTML user interfaces in Go."
 arch=('x86_64')
 url="https://github.com/a-h/templ"
@@ -15,5 +15,8 @@ source_x86_64=("templ-x86-x64-${pkgver}.tar.gz::https://github.com/a-h/templ/rel
 
 package() {
   install -Dm755 "./templ" "${pkgdir}/usr/bin/templ"
+
+  install -Dm0644 README.md "${pkgdir}/usr/share/doc/templ/README.md"
+  install -Dm0644 LICENSE "${pkgdir}/usr/share/licenses/templ/LICENSE"
 }
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,15 +2,15 @@
 # Contributor: thdxr (original PKGBUILD)
 # Contributor: Noel Jacob (bun-bin PKGBUILD)
 pkgname=templ-bin
-pkgver=0.2.648
-pkgrel=2
+pkgver=0.2.771
+pkgrel=1
 pkgdesc="A language for writing HTML user interfaces in Go."
 arch=('x86_64')
 url="https://github.com/a-h/templ"
 license=('MIT')
 provides=('templ')
 conflicts=('templ')
-sha256sums_x86_64=("3abad775c8ef0ff42181158e58b6d8746be7d3e2e194974345d97556ad668259")
+sha256sums_x86_64=('216aff42df8a7eb8855a0ee8f9b500069fb8e509157fc2aa5fad0f48e9a6d53e')
 source_x86_64=("templ-x86-x64-${pkgver}.tar.gz::https://github.com/a-h/templ/releases/download/v${pkgver}/templ_Linux_x86_64.tar.gz")
 
 package() {


### PR DESCRIPTION
Hi,

this PR's primary intent is to update the package to the latest upstream version.

It also installs the project's README.md and LICENSE files to their appropriate locations.

Lastly, the steps to install shell completions have been removed, as `templ` so far has not supported generating shell completions.
The current commands end up installing the binaries help text as completion commands for different shells, which does not provide the desired functionality of shell completion.

Let me know what you think.

Cheers